### PR TITLE
fix:fixes for go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,5 @@
-module kakify
+module github.com/DecodeWorms/kakify
+
 
 go 1.20
 


### PR DESCRIPTION
Fixes for go.mod
Changes the module path from kakify to github.com/DecodeWorms/kakify